### PR TITLE
Added config option "reapeat"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ cul.on('data', function (raw) {
     receive rssi (signal strength) value with every message (works only if init and parse are both true)
 * **debug** (default: ```false```)  
     log every command which is send in the console
+* **repeat** (default: ```false```)  
+    disable repeat message filtering in culfw, that means report each of the (repeated) packets of a message
 * **host** (no default value)  
     the IP-Address of CUNO (has to be set when using telnet mode)
 * **port** (default: ```2323```)  

--- a/cul.js
+++ b/cul.js
@@ -68,6 +68,7 @@ const Cul = function (options) {
     options.scc = options.scc || false;
     options.rssi = options.rssi || true;
     options.debug = options.debug || false;
+	options.repeat = options.repeat || false;
     options.connectionMode = options.connectionMode || 'serial';
     options.networkTimeout = options.networkTimeout || true;
     options.logger = options.logger || console.log;
@@ -86,6 +87,10 @@ const Cul = function (options) {
     if (options.rssi) {
         // Set flag, binary or
         options.initCmd |= 0x20;
+    }
+    if (options.repeat) {
+        // Set flag, binary or
+        options.initCmd |= 0x02;
     }
     options.initCmd = 'X' + ('0' + options.initCmd.toString(16)).slice(-2);
 

--- a/lib/fs20.js
+++ b/lib/fs20.js
@@ -141,7 +141,7 @@ module.exports.cmd = function (code, address, command, time, bidi, res) {
             command += '%';
         }
         if (commands.indexOf(command) !== -1) {
-            command = ('0' + commands.indexOf(command)).slice(-2).toString(16);
+            command = ('0' + (commands.indexOf(command).toString(16))).slice(-2);
         }
         command = command.toUpperCase();
     } else {


### PR DESCRIPTION
For tracking of FS20 dimmers I need that I receive every received packet from the CUL without filtering. For that I introduced the config option "repeat", wich sets bit 1 of the init comand to CUL. (see cmd "X, bit 1" in culfw: Report each of the (repeated) packets of a message).

Thanks very much for your work and hopefully for considering this pull request!