### PR TITLE
handle multiple messages in one telnet read

### DIFF
--- a/cul.js
+++ b/cul.js
@@ -220,7 +220,7 @@ const Cul = function (options) {
             }
 
             telnet.on('data', data => {
-                parse(data.toString().replace(/[\n\r]/g, ''));
+                data.toString().split(/\r?\n/).forEach(parse);
                 that.patWatchdog(); // Pat Watchdog
             });
 


### PR DESCRIPTION
Sometimes two messages were in the telnet buffer, and removing the \r\n
caused them to be handed to parse() as one message. It then could not
validate the structure, as the total length mismatched the first given
length header.

This fixes this by splitting the messages and parsing them separately
from each other.