### PR TITLE
Change controlpoint time from start to end time

### DIFF
--- a/lib/moritz.js
+++ b/lib/moritz.js
@@ -342,21 +342,25 @@ module.exports.parse = function (raw) {
 				data.weekday = data.payload.substr(1,1);
 				data.weekdayStr = day2str[data.weekday];
 				data.controlpoints = [];
+				let previousHour = 0;
+				let previousMinute = 0;
 				for(var i=0; i<controlpointCount; i++) {
 					let controlpoint = hex2byte(data.payload.substr(2+(i*4),4));
 					let temperature = ((controlpoint >> 9) & 0x3F) / 2;
 					let time = (controlpoint & 0x1FF) * 5;
-					let hour = (time / 60) % 24;
+					let hour = Math.floor((time / 60) % 24);
 					let minute = time % 60;
 					data.controlpoints.push({
 						temperature: temperature,
-						hour: hour,
-						minute: minute
+						hour: previousHour,
+						minute: previousMinute
 					});
 					if (hour === 0 && minute === 0) {
 						// Last point.
 						break;
 					}
+					previousHour = hour;
+					previousMinute = minute;
 				}	
 			}
 			else {


### PR DESCRIPTION
Times per controlpoint were end time instead of start times. This change modifies them to start times.
This will break backwards compatibility but it reporting the start time is more sense than end time.